### PR TITLE
test n_cores = 1 in github action

### DIFF
--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/vignettes/likelihood_profile.Rmd
+++ b/vignettes/likelihood_profile.Rmd
@@ -62,9 +62,10 @@ like_fit <- run_fims_likelihood(
   parameters = parameters,
   parameter_name = "log_rzero", 
   data = data1,
+  n_cores = 1,
   min = -1,
   max = 1,
-  length = 10
+  length = 5
 )
 
 plot_likelihood(like_fit)


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Reducing n_cores from 5 to 1 in vignette to see if it helps with this error:
  > https://github.com/NOAA-FIMS/FIMSdiags/actions/runs/20324368743/job/58386409549#step:9:290
``` 
  Errors in running code in vignettes:
  when running code in ‘likelihood_profile.Rmd’
    ...
  +     parameters = parameters, parameter_name = "log_rzero", data = data1, 
  +     min = -1, max .... [TRUNCATED] 
  ℹ parameter values being profiles over: 12.857, 13.0792222222222, 13.3014444444444, 13.5236666666667, 13.7458888888889, 13.9681111111111, 14.1903333333333, 14.4125555555556, 14.6347777777778, 14.857
  ...Running in parallel with multicore
  Warning in mccollect(jobs = jobs, wait = TRUE) :
    1 parallel job did not deliver a result
```

No need to merge this PR, just created to test the github action
